### PR TITLE
Add toThrow()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .nyc_output
 coverage
 Thumbs.db
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+/.*
+/coverage
+/src
+node_modules
+npm-debug.log
+.DS_Store
+.nyc_output
+tsconfig.json
+*.tgz
+*.test.*

--- a/src/array.ts
+++ b/src/array.ts
@@ -3,7 +3,7 @@ import { either, isLeft, left } from 'fp-ts/Either'
 
 import { branchError, leafError } from './errors'
 import { failure, isFailure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 
 export interface ArrayOptions {
   minLength?: number

--- a/src/boolean.ts
+++ b/src/boolean.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 
 export function boolean(): Validator<boolean> {
   return (value: unknown) => {

--- a/src/date.ts
+++ b/src/date.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 
 export interface DateOptions {
   min?: Date

--- a/src/enumerate.ts
+++ b/src/enumerate.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 
 export function enumerate<T extends (string | number)[]>(
   ...args: T

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export * from './errors'
 export * from './result'
-export * from './validate'
+export * from './transformer'
 
 export * from './array'
 export * from './boolean'

--- a/src/number.ts
+++ b/src/number.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 
 export interface NumberOptions {
   min?: number

--- a/src/object.test.ts
+++ b/src/object.test.ts
@@ -4,7 +4,7 @@ import { object, defaultTo, optional } from './object'
 import { string } from './string'
 import { branchError, leafError } from './errors'
 import { failure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 import { number } from './number'
 
 describe('object()', () => {

--- a/src/object.ts
+++ b/src/object.ts
@@ -3,7 +3,7 @@ import { either, Either, isLeft, left, right } from 'fp-ts/lib/Either'
 import { pipe } from 'fp-ts/lib/function'
 import { branchError, ChildError, leafError } from './errors'
 import { failure, isFailure, success } from './result'
-import { Validator, ValidatorReturnType } from './validate'
+import { Validator, ValidatorReturnType } from './transformer'
 
 export type ObjectValueValidator = Validator<unknown> & { optional?: boolean }
 export type ObjectDefinition = Record<string, ObjectValueValidator>

--- a/src/parse-boolean.ts
+++ b/src/parse-boolean.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Transformer } from './validate'
+import { Transformer } from './transformer'
 
 export function parseBoolean(): Transformer<string, boolean> {
   return (value: string) => {

--- a/src/parse-date.ts
+++ b/src/parse-date.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Transformer } from './validate'
+import { Transformer } from './transformer'
 
 const isoDateRegex = /^\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d(\.\d+)?([+-][0-2]\d:[0-5]\d|Z)$/
 

--- a/src/parse-json.ts
+++ b/src/parse-json.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Transformer } from './validate'
+import { Transformer } from './transformer'
 
 export function parseJson(): Transformer<string, unknown> {
   return (value: string) => {

--- a/src/parse-number.ts
+++ b/src/parse-number.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Transformer } from './validate'
+import { Transformer } from './transformer'
 
 export function parseNumber(): Transformer<string, number> {
   return (value: string) => {

--- a/src/string.ts
+++ b/src/string.ts
@@ -1,6 +1,6 @@
 import { leafError } from './errors'
 import { failure, success } from './result'
-import { Validator } from './validate'
+import { Validator } from './transformer'
 
 export interface StringOptions {
   minLength?: number

--- a/src/throw.test.ts
+++ b/src/throw.test.ts
@@ -1,0 +1,13 @@
+import { assert } from 'chai'
+
+import { string } from './string'
+import { FefeThrowError, toThrow } from './throw'
+
+describe('toThrow()', () => {
+  const validate = toThrow(string())
+
+  it('should throw an error if validator returns error', () =>
+    assert.throws(() => validate(1), FefeThrowError, 'Not a string.'))
+
+  it('should validate', () => assert.deepStrictEqual(validate('foo'), 'foo'))
+})

--- a/src/throw.ts
+++ b/src/throw.ts
@@ -1,0 +1,24 @@
+import { FefeError, getErrorString } from './errors'
+import { isFailure } from './result'
+import { Transformer } from './transformer'
+
+export class ExtendableError extends Error {
+  constructor(message: string) {
+    super(message)
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
+export class FefeThrowError extends ExtendableError {
+  constructor(public error: FefeError) {
+    super(getErrorString(error))
+  }
+}
+
+export function toThrow<V, T>(transformer: Transformer<V, T>): (v: V) => T {
+  return (v: V) => {
+    const result = transformer(v)
+    if (isFailure(result)) throw new FefeThrowError(result.left)
+    return result.right
+  }
+}

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,14 +1,6 @@
-import { isFailure, Result } from './result'
+import { Result } from './result'
 
 export type Transformer<V, T> = (v: V) => Result<T>
 
 export type Validator<T> = Transformer<unknown, T>
 export type ValidatorReturnType<T> = T extends Validator<infer U> ? U : never
-
-export function toThrow<V, T>(transformer: Transformer<V, T>): (v: V) => T {
-  return (v: V) => {
-    const result = transformer(v)
-    if (isFailure(result)) throw result.left
-    return result.right
-  }
-}

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -1,0 +1,14 @@
+import { isFailure, Result } from './result'
+
+export type Transformer<V, T> = (v: V) => Result<T>
+
+export type Validator<T> = Transformer<unknown, T>
+export type ValidatorReturnType<T> = T extends Validator<infer U> ? U : never
+
+export function toThrow<V, T>(transformer: Transformer<V, T>): (v: V) => T {
+  return (v: V) => {
+    const result = transformer(v)
+    if (isFailure(result)) throw result.left
+    return result.right
+  }
+}

--- a/src/union.ts
+++ b/src/union.ts
@@ -1,6 +1,6 @@
 import { FefeError, leafError, getErrorString } from './errors'
 import { failure, isSuccess, success } from './result'
-import { Validator, ValidatorReturnType } from './validate'
+import { Validator, ValidatorReturnType } from './transformer'
 
 export function union<T extends Validator<unknown>[]>(
   ...validators: T

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,6 +1,0 @@
-import { Result } from './result'
-
-export type Transformer<V, T> = (v: V) => Result<T>
-
-export type Validator<T> = Transformer<unknown, T>
-export type ValidatorReturnType<T> = T extends Validator<infer U> ? U : never


### PR DESCRIPTION
For migrating from fefe@2 codebases it's useful to have the ability to throw errors instead of checking `Either`.